### PR TITLE
Add Dart to Uncommenter.REGEX_PATTERNS

### DIFF
--- a/lib/uncommenter.ts
+++ b/lib/uncommenter.ts
@@ -9,6 +9,7 @@ export default class Uncommenter {
     cpp: Uncommenter.DOUBLE_SLASHES,
     csharp: Uncommenter.DOUBLE_SLASHES,
     crystal: Uncommenter.POUND_SIGN,
+    dart: Uncommenter.DOUBLE_SLASHES,
     elixir: Uncommenter.POUND_SIGN,
     gleam: Uncommenter.DOUBLE_SLASHES,
     go: Uncommenter.DOUBLE_SLASHES,


### PR DESCRIPTION
I believe not having this is the reason for the failure trying to add to http-server here:

https://github.com/codecrafters-io/build-your-own-http-server/actions/runs/9514796246/job/26227695837?pr=76#step:10:112

@rohitpaulk 