### PR TITLE
CC-1391: Figure out why CI tests end early for Kotlin (SQLite)

### DIFF
--- a/.github/workflows/test-course-definition.yml
+++ b/.github/workflows/test-course-definition.yml
@@ -245,8 +245,34 @@ jobs:
       - run: git config --global user.email "hello@codecrafters.io"
       - run: git config --global user.name "codecrafters-bot"
 
-      - run: course-sdk test ${{matrix.language}}
+      - name: course-sdk-test
+        run: |
+          echo repo.name: ${{github.event.repository.name}}
+          prefix="build-your-own-"
+          repo=${{github.event.repository.name}}
+          slug="${repo#$prefix}"
+          echo slug: $slug
+          course-sdk test ${{matrix.language}} && cp -r /tmp/testers/$slug $HOME/
+          echo ✅ $slug "tester copied to $HOME/$slug"
+        shell: bash
         working-directory: courses/${{github.event.repository.name}}
+
+      - name: sanity-check
+        run: |
+          echo repo.name: ${{github.event.repository.name}}
+          prefix="build-your-own-"
+          repo=${{github.event.repository.name}}
+          slug="${repo#$prefix}"
+          echo slug: $slug
+          echo "🗂️ ls -l $HOME/$slug:"
+          ls -l "$HOME/$slug"
+          if [ -d "$HOME/$slug" ]; then
+            echo ✅ $slug "tester directory exists."
+          else
+            echo ❌ $slug "tester directory does not exist."
+            exit 1
+          fi
+        shell: bash
 
   validate-schemas:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I didn't end up figuring out why it happened, but this PR fixes the issue by:

1. Logging out everything about the file stream. It beats me why simply observing it can banish the phantom, but silent exits just won't repeat themselves anymore.

<img width="1570" alt="logs" src="https://github.com/user-attachments/assets/1e737ff3-104c-4017-85f7-ab0ecb6b9457">

---

2. Adding sanity check which will fail the job if `course-sdk test` silently quits again and leaves no tester artifact behind.

<img width="742" alt="sanity check" src="https://github.com/user-attachments/assets/b762b662-87db-4c2a-a24a-0eecd2eeeb75">

