### PR TITLE
Upgrade rust-tools to 1.80-bookworm

### DIFF
--- a/lib/dockerfiles/rust-tools.Dockerfile
+++ b/lib/dockerfiles/rust-tools.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.70-buster
+FROM rust:1.80-bookworm
 
 WORKDIR /workdir
 


### PR DESCRIPTION
Need 1.80-bookworm to pass linting for Interpreter.

https://github.com/codecrafters-io/build-your-own-interpreter/actions/runs/11337388117/job/31528910206?pr=50

<img width="1354" alt="image" src="https://github.com/user-attachments/assets/5ba991d3-dbca-4363-b986-a9371f58cf16">
