### PR TITLE
Add support for generated deterministic UUIDs in language templates

### DIFF
--- a/commands/add-language.ts
+++ b/commands/add-language.ts
@@ -48,8 +48,27 @@ export default class AddLanguageCommand extends BaseCommand {
       course_slug: course.slug,
       course_slug_underscorized: course.slug.replace("-", "_"),
       course_name: course.name,
+      uppercased_uuid1: this.#generateDeterministicUUID(course.slug, this.languageSlug, "1").toUpperCase(),
+      uppercased_uuid2: this.#generateDeterministicUUID(course.slug, this.languageSlug, "2").toUpperCase(),
     };
   }
+
+  #generateDeterministicUUID(courseSlug: string, languageSlug: string, suffix: string): string {
+    const input = `${suffix}-${courseSlug}-${languageSlug}`;
+    let hash = 0;
+    
+    // Generate a simple hash from the input string
+    for (let i = 0; i < input.length; i++) {
+      const char = input.charCodeAt(i);
+      hash = ((hash << 5) - hash) + char;
+      hash = hash & hash; // Convert to 32-bit integer
+    }
+
+    // Convert the hash to a UUID-like format
+    const hashStr = Math.abs(hash).toString(16).padStart(8, '0');
+    return `${hashStr.slice(0, 8)}-${hashStr.slice(0, 4)}-4${hashStr.slice(1, 4)}-${hashStr.slice(0, 4)}-${hashStr.slice(0, 12)}`;
+  }
+
 
   async #copyConfigYml(course: Course, languageTemplatesDir: string) {
     const configYmlPath = path.join(languageTemplatesDir, "config.yml");

--- a/commands/add-language.ts
+++ b/commands/add-language.ts
@@ -64,11 +64,20 @@ export default class AddLanguageCommand extends BaseCommand {
       hash = hash & hash; // Convert to 32-bit integer
     }
 
-    // Convert the hash to a UUID-like format
-    const hashStr = Math.abs(hash).toString(16).padStart(8, '0');
-    return `${hashStr.slice(0, 8)}-${hashStr.slice(0, 4)}-4${hashStr.slice(1, 4)}-${hashStr.slice(0, 4)}-${hashStr.slice(0, 12)}`;
-  }
+    // Create multiple hash values for different segments
+    const hash1 = Math.abs(hash).toString(16).padStart(8, '0').slice(0, 8);
+    const hash2 = Math.abs(hash * 31).toString(16).padStart(4, '0').slice(0, 4);
+    const hash3 = Math.abs(hash * 47).toString(16).padStart(4, '0').slice(0, 4);
+    const hash4 = Math.abs(hash * 67).toString(16).padStart(4, '0').slice(0, 4);
+    const hash5 = Math.abs(hash * 97).toString(16).padStart(12, '0').slice(0, 12);
 
+    // Ensure UUID v4 compliance: Set version to '4' and variant to '8-b'
+    const versionedHash3 = `4${hash3.slice(1)}`;
+    const variantHash4 = ((parseInt(hash4[0], 16) & 0x3) | 0x8).toString(16) + hash4.slice(1);
+    
+    // Format as UUID v4 with correct version (4) and variant (8-b) bits
+    return `${hash1}-${hash2}-${versionedHash3}-${variantHash4}-${hash5}`.toUpperCase();
+  }
 
   async #copyConfigYml(course: Course, languageTemplatesDir: string) {
     const configYmlPath = path.join(languageTemplatesDir, "config.yml");

--- a/commands/add-language.ts
+++ b/commands/add-language.ts
@@ -48,8 +48,8 @@ export default class AddLanguageCommand extends BaseCommand {
       course_slug: course.slug,
       course_slug_underscorized: course.slug.replace("-", "_"),
       course_name: course.name,
-      uppercased_uuid1: this.#generateDeterministicUUID(course.slug, this.languageSlug, "1").toUpperCase(),
-      uppercased_uuid2: this.#generateDeterministicUUID(course.slug, this.languageSlug, "2").toUpperCase(),
+      uppercased_uuid_1: this.#generateDeterministicUUID(course.slug, this.languageSlug, "1").toUpperCase(),
+      uppercased_uuid_2: this.#generateDeterministicUUID(course.slug, this.languageSlug, "2").toUpperCase(),
     };
   }
 


### PR DESCRIPTION
This pull request adds support for generating deterministic UUIDs in language templates. The `AddLanguageCommand` class now includes a method `#generateDeterministicUUID` that takes in the course slug, language slug, and a suffix to generate a UUID-like string. This method generates a hash from the input string and converts it to a UUID-like format. The generated UUIDs are then used in the `AddLanguageCommand` class to populate the `uppercased_uuid1` and `uppercased_uuid2` properties in the template data. This enhancement improves the uniqueness and determinism of the generated UUIDs in the language templates.