### PR TITLE
Update lint command to check directory existence before running cargo clippy

### DIFF
--- a/commands/lint.ts
+++ b/commands/lint.ts
@@ -84,7 +84,7 @@ export default class LintCommand extends BaseCommand {
   async lintRustFiles() {
     const dockerShellCommandExecutor = await this.dockerShellCommandExecutor("rust-tools");
     await dockerShellCommandExecutor.exec(`find . -name '*.rs' -exec rustfmt --edition "2021" --check -- {} +`);
-    await dockerShellCommandExecutor.exec("cd compiled_starters/rust && cargo clippy --fix --allow-dirty");
+    await dockerShellCommandExecutor.exec("[ -d compiled_starters/rust ] && (cd compiled_starters/rust && cargo clippy --fix --allow-dirty) || exit 0");
   }
 
   async lintDockerFilesHelper(tmpDirectory: string) {


### PR DESCRIPTION
Ensure the lint command verifies the existence of the `compiled_starters/rust` directory before executing `cargo clippy`, preventing errors when the directory is missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented errors during linting by skipping the Rust linting step if the relevant directory does not exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->