### PR TITLE
Fix lint command logic for Rust files

### DIFF
--- a/commands/lint.ts
+++ b/commands/lint.ts
@@ -84,7 +84,7 @@ export default class LintCommand extends BaseCommand {
   async lintRustFiles() {
     const dockerShellCommandExecutor = await this.dockerShellCommandExecutor("rust-tools");
     await dockerShellCommandExecutor.exec(`find . -name '*.rs' -exec rustfmt --edition "2021" --check -- {} +`);
-    await dockerShellCommandExecutor.exec("[ -d compiled_starters/rust ] && (cd compiled_starters/rust && cargo clippy --fix --allow-dirty) || exit 0");
+    await dockerShellCommandExecutor.exec("[ -d compiled_starters/rust ] || exit 0 && (cd compiled_starters/rust && cargo clippy --fix --allow-dirty)");
   }
 
   async lintDockerFilesHelper(tmpDirectory: string) {


### PR DESCRIPTION
Ensure the directory existence check occurs before executing cargo clippy, improving the linting process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Adjusted the logic for running linting on Rust files to improve reliability when the target directory is absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->