### PR TITLE
Add `course_slug_pascalized`

### DIFF
--- a/commands/add-language.ts
+++ b/commands/add-language.ts
@@ -72,22 +72,10 @@ export default class AddLanguageCommand extends BaseCommand {
 
     // Create multiple hash values for different segments
     const hash1 = Math.abs(hash).toString(16).padStart(8, "0").slice(0, 8);
-    const hash2 = Math.abs(hash * 31)
-      .toString(16)
-      .padStart(4, "0")
-      .slice(0, 4);
-    const hash3 = Math.abs(hash * 47)
-      .toString(16)
-      .padStart(4, "0")
-      .slice(0, 4);
-    const hash4 = Math.abs(hash * 67)
-      .toString(16)
-      .padStart(4, "0")
-      .slice(0, 4);
-    const hash5 = Math.abs(hash * 97)
-      .toString(16)
-      .padStart(12, "0")
-      .slice(0, 12);
+    const hash2 = Math.abs(hash * 31).toString(16).padStart(4, "0").slice(0, 4);
+    const hash3 = Math.abs(hash * 47).toString(16).padStart(4, "0").slice(0, 4);
+    const hash4 = Math.abs(hash * 67).toString(16).padStart(4, "0").slice(0, 4);
+    const hash5 = Math.abs(hash * 97).toString(16).padStart(12, "0").slice(0, 12);
 
     // Ensure UUID v4 compliance: Set version to '4' and variant to '8-b'
     const versionedHash3 = `4${hash3.slice(1)}`;

--- a/commands/add-language.ts
+++ b/commands/add-language.ts
@@ -44,8 +44,14 @@ export default class AddLanguageCommand extends BaseCommand {
   }
 
   #buildTemplateContext(course: Course) {
+    const courseSlugPascalized = course.slug
+      .split("-")
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join("");
+
     return {
       course_slug: course.slug,
+      course_slug_pascalized: courseSlugPascalized,
       course_slug_underscorized: course.slug.replace("-", "_"),
       course_name: course.name,
       uppercased_uuid_1: this.#generateDeterministicUUID(course.slug, this.languageSlug, "1").toUpperCase(),
@@ -56,25 +62,37 @@ export default class AddLanguageCommand extends BaseCommand {
   #generateDeterministicUUID(courseSlug: string, languageSlug: string, suffix: string): string {
     const input = `${suffix}-${courseSlug}-${languageSlug}`;
     let hash = 0;
-    
+
     // Generate a simple hash from the input string
     for (let i = 0; i < input.length; i++) {
       const char = input.charCodeAt(i);
-      hash = ((hash << 5) - hash) + char;
+      hash = (hash << 5) - hash + char;
       hash = hash & hash; // Convert to 32-bit integer
     }
 
     // Create multiple hash values for different segments
-    const hash1 = Math.abs(hash).toString(16).padStart(8, '0').slice(0, 8);
-    const hash2 = Math.abs(hash * 31).toString(16).padStart(4, '0').slice(0, 4);
-    const hash3 = Math.abs(hash * 47).toString(16).padStart(4, '0').slice(0, 4);
-    const hash4 = Math.abs(hash * 67).toString(16).padStart(4, '0').slice(0, 4);
-    const hash5 = Math.abs(hash * 97).toString(16).padStart(12, '0').slice(0, 12);
+    const hash1 = Math.abs(hash).toString(16).padStart(8, "0").slice(0, 8);
+    const hash2 = Math.abs(hash * 31)
+      .toString(16)
+      .padStart(4, "0")
+      .slice(0, 4);
+    const hash3 = Math.abs(hash * 47)
+      .toString(16)
+      .padStart(4, "0")
+      .slice(0, 4);
+    const hash4 = Math.abs(hash * 67)
+      .toString(16)
+      .padStart(4, "0")
+      .slice(0, 4);
+    const hash5 = Math.abs(hash * 97)
+      .toString(16)
+      .padStart(12, "0")
+      .slice(0, 12);
 
     // Ensure UUID v4 compliance: Set version to '4' and variant to '8-b'
     const versionedHash3 = `4${hash3.slice(1)}`;
     const variantHash4 = ((parseInt(hash4[0], 16) & 0x3) | 0x8).toString(16) + hash4.slice(1);
-    
+
     // Format as UUID v4 with correct version (4) and variant (8-b) bits
     return `${hash1}-${hash2}-${versionedHash3}-${variantHash4}-${hash5}`.toUpperCase();
   }


### PR DESCRIPTION
Context (member feedback):

<img width="478" alt="image" src="https://github.com/user-attachments/assets/d02f3d12-d34e-4718-bef9-5dfb993c18b1" />

---


The intended change is:

```
    const courseSlugPascalized = course.slug
      .split("-")
      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
      .join("");

    return {
      course_slug: course.slug,
      course_slug_pascalized: courseSlugPascalized, 
```

The rest are just from prettier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for a PascalCase variant of course slugs to improve template handling.

- **Style**
  - Improved code formatting for better readability in internal processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->