### PR TITLE
add `with { type: 'file' }` to shell imports

### DIFF
--- a/lib/testers/solution-tester.ts
+++ b/lib/testers/solution-tester.ts
@@ -11,7 +11,7 @@ import Dockerfile from "../models/dockerfile";
 import Language from "../models/language";
 import CourseStage from "../models/course-stage";
 // @ts-ignore
-import testScriptFile from "../scripts/test.sh";
+import testScriptFile from "../scripts/test.sh" with { type: "file" };
 
 const exec = util.promisify(child_process.exec);
 const readFile = util.promisify(fs.readFile);

--- a/lib/testers/starter-code-tester.ts
+++ b/lib/testers/starter-code-tester.ts
@@ -10,7 +10,7 @@ import path from "path";
 import YAML from "js-yaml";
 import StarterCodeUncommenter from "../starter-code-uncommenter";
 import LineWithCommentRemover from "../line-with-comment-remover";
-import testScriptFile from "../scripts/test.sh";
+import testScriptFile from "../scripts/test.sh" with { type: "file" };
 import ShellCommandExecutor from "../shell-command-executor";
 import Dockerfile from "../models/dockerfile";
 


### PR DESCRIPTION
These were importing as undefined. 

Fixes #53 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal handling of script file imports for improved file resource management. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->