### PR TITLE
fix: test script path

### DIFF
--- a/lib/testers/solution-tester.ts
+++ b/lib/testers/solution-tester.ts
@@ -10,8 +10,8 @@ import Course from "../models/course";
 import Dockerfile from "../models/dockerfile";
 import Language from "../models/language";
 import CourseStage from "../models/course-stage";
-// @ts-ignore
-import testScriptFile from "../scripts/test.sh";
+
+const testScriptFile = path.join(__dirname, "../scripts/test.sh")
 
 const exec = util.promisify(child_process.exec);
 const readFile = util.promisify(fs.readFile);

--- a/lib/testers/solution-tester.ts
+++ b/lib/testers/solution-tester.ts
@@ -10,8 +10,8 @@ import Course from "../models/course";
 import Dockerfile from "../models/dockerfile";
 import Language from "../models/language";
 import CourseStage from "../models/course-stage";
-
-const testScriptFile = path.join(__dirname, "../scripts/test.sh")
+// @ts-ignore
+import testScriptFile from "../scripts/test.sh" with { type: 'text'};
 
 const exec = util.promisify(child_process.exec);
 const readFile = util.promisify(fs.readFile);
@@ -82,7 +82,7 @@ export default class SolutionTester extends BaseTester {
     // TODO: Using tmp.fileSync() here causes "Text file busy" errors on GitHub runners
     const testScriptPath = tmp.tmpNameSync();
 
-    await writeFile(testScriptPath, fs.readFileSync(testScriptFile).toString());
+    await writeFile(testScriptPath, testScriptFile);
     await exec(`chmod +x ${testScriptPath}`);
     await exec(`sync`); // Avoid "Text file busy" errors
 

--- a/lib/testers/starter-code-tester.ts
+++ b/lib/testers/starter-code-tester.ts
@@ -10,12 +10,12 @@ import path from "path";
 import YAML from "js-yaml";
 import StarterCodeUncommenter from "../starter-code-uncommenter";
 import LineWithCommentRemover from "../line-with-comment-remover";
-import testScriptFile from "../scripts/test.sh";
 import ShellCommandExecutor from "../shell-command-executor";
 import Dockerfile from "../models/dockerfile";
 
-const writeFile = util.promisify(fs.writeFile);
+const testScriptFile = path.join(__dirname, "../scripts/test.sh")
 
+const writeFile = util.promisify(fs.writeFile);
 const exec = util.promisify(child_process.exec);
 const readFile = util.promisify(fs.readFile);
 

--- a/lib/testers/starter-code-tester.ts
+++ b/lib/testers/starter-code-tester.ts
@@ -10,10 +10,10 @@ import path from "path";
 import YAML from "js-yaml";
 import StarterCodeUncommenter from "../starter-code-uncommenter";
 import LineWithCommentRemover from "../line-with-comment-remover";
+// @ts-ignore
+import testScriptFile from "../scripts/test.sh" with { type: "text" };
 import ShellCommandExecutor from "../shell-command-executor";
 import Dockerfile from "../models/dockerfile";
-
-const testScriptFile = path.join(__dirname, "../scripts/test.sh")
 
 const writeFile = util.promisify(fs.writeFile);
 const exec = util.promisify(child_process.exec);
@@ -194,7 +194,7 @@ export default class StarterCodeTester extends BaseTester {
     // TODO: Using tmp.fileSync() here causes "Text file busy" errors on GitHub runners
     const testScriptPath = tmp.tmpNameSync();
 
-    await writeFile(testScriptPath, fs.readFileSync(testScriptFile).toString());
+    await writeFile(testScriptPath, testScriptFile);
     await exec(`chmod +x ${testScriptPath}`);
     await exec(`sync`); // Avoid "Text file busy" errors
 


### PR DESCRIPTION
`course-sdk test <lang> <stage>` was failing because of empty `testScriptFile` variable. 

![Screenshot 2025-06-17 at 11 28 45](https://github.com/user-attachments/assets/82f845c9-878f-4b7f-911d-4ea1ac2e7f5d)

