### PR TITLE
Add concept_slugs property to schema for courses and stages.

### DIFF
--- a/schemas/course-definition.json
+++ b/schemas/course-definition.json
@@ -38,6 +38,14 @@
       "not": { "type": "null" },
       "description": "The percentage of users who complete this course. Set to 5% if we don't have data yet."
     },
+    "concept_slugs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Slugs for the concepts covered in the course."
+      }
+    },
     "languages": {
       "type": "array",
       "items": {
@@ -160,6 +168,14 @@
             "type": "string",
             "minLength": 1,
             "description": "The name of this stage. Example: `Respond to PING`"
+          },
+          "concept_slugs": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Slugs for the concepts covered in this stage."
+            }
           },
           "difficulty": {
             "type": "string",


### PR DESCRIPTION
Issue:

https://github.com/codecrafters-io/build-your-own-redis/actions/runs/18748473198/job/53481517369

<img width="1696" height="618" alt="image" src="https://github.com/user-attachments/assets/ee8edf5d-dc98-4356-8d2a-a95e0966bfa1" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `concept_slugs` array fields to the course schema and each stage schema.
> 
> - **Schema (`schemas/course-definition.json`)**:
>   - **Course-level**: Add `concept_slugs` as an array of non-empty strings.
>   - **Stage-level**: Add `concept_slugs` as an array of non-empty strings alongside existing stage properties.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 152b5df4bc28efa50522a0f9f869ebfdd0bd1760. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->