### PR TITLE
CC-1984: Update uncomment markers in code and tests to use consistent phrasing

### DIFF
--- a/lib/compilers/first-stage-solutions-compiler.ts
+++ b/lib/compilers/first-stage-solutions-compiler.ts
@@ -54,7 +54,7 @@ export default class FirstStageSolutionsCompiler {
     diffs.forEach((diff) => {
       if (diff.toString() === "") {
         console.error("Expected uncommenting code to return a diff");
-        console.error("Are you sure there's a contiguous block of comments after the 'Uncomment this' marker?");
+        console.error("Are you sure there's a contiguous block of comments after the 'Uncomment the' marker?");
 
         process.exit(1);
       }

--- a/lib/starter-code-uncommenter.ts
+++ b/lib/starter-code-uncommenter.ts
@@ -15,7 +15,7 @@ export default class StarterCodeUncommenter {
   private dir: string;
   private language: Language;
 
-  private static UNCOMMENT_MARKER_PATTERN = /Uncomment this/;
+  private static UNCOMMENT_MARKER_PATTERN = /Uncomment the/;
 
   constructor(dir: string, language: Language) {
     this.dir = dir;

--- a/lib/testers/starter-code-tester.ts
+++ b/lib/testers/starter-code-tester.ts
@@ -125,7 +125,7 @@ export default class StarterCodeTester extends BaseTester {
     for (const diff of diffs) {
       if (diff.toString() === "") {
         Logger.logError("Expected uncommenting code to return a diff");
-        Logger.logError("Are you sure there's a contiguous block of comments after the 'Uncomment this' marker?");
+        Logger.logError("Are you sure there's a contiguous block of comments after the 'Uncomment the' marker?");
         return;
       }
 

--- a/lib/uncommenter.test.ts
+++ b/lib/uncommenter.test.ts
@@ -6,12 +6,12 @@ test("", () => {
 
 import Uncommenter from "./uncommenter";
 
-const UNCOMMENT_PATTERN = /Uncomment this/;
+const UNCOMMENT_PATTERN = /Uncomment the/;
 
 const SAMPLE_PY_COMMENTED = `
 abcd = true
 
-# Uncomment this to pass the first stage
+# Uncomment the code below to pass the first stage
 #
 # # This is an assignment
 # a = b
@@ -40,7 +40,7 @@ yay = true
 
 const SAMPLE_GO_COMMENTED = `
 func main() {
-  // Uncomment this to pass the first stage
+  // Uncomment the code below to pass the first stage
   //
   // // This is an assignment
   // a := 1
@@ -64,7 +64,7 @@ func main() {
 
 const SAMPLE_HASKELL_COMMENTD = `
 main = do
- -- Uncomment this to pass the first stage
+ -- Uncomment the code below to pass the first stage
  -- a <- readLine
  -- b <- readLine
  -- -- Nested Comment
@@ -81,7 +81,7 @@ main = do
 
 const SAMPLE_JAVA_COMMENTED = `
 public static void main(String[] args) {
-  // Uncomment this to pass the first stage
+  // Uncomment the code below to pass the first stage
   //
   // // This is an assignment
   // int a = 1;
@@ -105,7 +105,7 @@ public static void main(String[] args) {
 
 const SAMPLE_KOTLIN_COMMENTED = `
 fun main(args: Array<String>) {
-  // Uncomment this to pass the first stage
+  // Uncomment the code below to pass the first stage
   //
   // // This is an assignment
   // val a = 1;
@@ -129,7 +129,7 @@ fun main(args: Array<String>) {
 
 const SAMPLE_PHP_COMMENTED = `
 <?php
-// Uncomment this to pass the first stage.
+// Uncomment the code below to pass the first stage.
 // $a = 1;
 // $b = 1;
 
@@ -147,7 +147,7 @@ $b = 1;
 `;
 
 const SAMPLE_JAVASCRIPT_COMMENTED = `
-// Uncomment this to pass the first stage
+// Uncomment the code below to pass the first stage
 // var a = 1;
 // var b = 2;
 // console.log(a + b);
@@ -160,7 +160,7 @@ console.log(a + b);
 `;
 
 const SAMPLE_CSHARP_COMMENTED = `
-// Uncomment this to pass the first stage
+// Uncomment the code below to pass the first stage
 // var a = 1;
 // var b = 2;
 // Console.WriteLine(a + b);
@@ -175,12 +175,12 @@ Console.WriteLine(a + b);
 const SAMPLE_TWO_MARKERS_COMMENTED = `
 a = b
 
-# Uncomment this to pass the first stage
+# Uncomment the code below to pass the first stage
 #
 # # First uncommented block
 # b = c
 
-# Uncomment this to pass the first stage
+# Uncomment the code below to pass the first stage
 #
 # # Second uncommented block
 # c = d
@@ -198,7 +198,7 @@ c = d
 
 const SAMPLE_OCAML_COMMENTED = `
 let main () =
-  (* Uncomment this to pass the first stage *)
+  (* Uncomment the code below to pass the first stage *)
   (* let a = 1 in *)
   (* let b = 2 in *)
   (* Printf.printf "%d\\n" (a + b) *)
@@ -343,7 +343,7 @@ test("uncommentedBlocksWithMarker", () => {
     `
     a = b
 
-    # Uncomment this to pass the first stage
+    # Uncomment the code below to pass the first stage
     # a = b
 
     c = d
@@ -351,7 +351,7 @@ test("uncommentedBlocksWithMarker", () => {
     UNCOMMENT_PATTERN
   ).uncommentedBlocksWithMarker;
 
-  const expected = `    # Uncomment this to pass the first stage
+  const expected = `    # Uncomment the code below to pass the first stage
     a = b`;
 
   expect(actual[0]).toBe(expected);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Standardizes the uncomment marker from "Uncomment this" to "Uncomment the/code below" across code, logs, and tests.
> 
> - **Core**:
>   - Update `StarterCodeUncommenter.UNCOMMENT_MARKER_PATTERN` to `/Uncomment the/`.
>   - Adjust error/log messages in `lib/compilers/first-stage-solutions-compiler.ts` and `lib/testers/starter-code-tester.ts` to reference the new marker.
> - **Tests**:
>   - Update `UNCOMMENT_PATTERN` and sample commented blocks in `lib/uncommenter.test.ts` (Python, Go, Haskell, Java, Kotlin, PHP, JavaScript, C#, OCaml) to the new phrasing.
>   - Fix expected strings for `uncommentedBlocksWithMarker` and multi-marker scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6aadda48fbebfa1d953329659def195f2ec36d55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->