### PR TITLE
Revert "CC-1984: Update uncomment markers in code and tests to use consistent phrasing"

### DIFF
--- a/lib/compilers/first-stage-solutions-compiler.ts
+++ b/lib/compilers/first-stage-solutions-compiler.ts
@@ -54,7 +54,7 @@ export default class FirstStageSolutionsCompiler {
     diffs.forEach((diff) => {
       if (diff.toString() === "") {
         console.error("Expected uncommenting code to return a diff");
-        console.error("Are you sure there's a contiguous block of comments after the 'Uncomment the' marker?");
+        console.error("Are you sure there's a contiguous block of comments after the 'Uncomment this' marker?");
 
         process.exit(1);
       }

--- a/lib/starter-code-uncommenter.ts
+++ b/lib/starter-code-uncommenter.ts
@@ -15,7 +15,7 @@ export default class StarterCodeUncommenter {
   private dir: string;
   private language: Language;
 
-  private static UNCOMMENT_MARKER_PATTERN = /Uncomment the/;
+  private static UNCOMMENT_MARKER_PATTERN = /Uncomment this/;
 
   constructor(dir: string, language: Language) {
     this.dir = dir;

--- a/lib/testers/starter-code-tester.ts
+++ b/lib/testers/starter-code-tester.ts
@@ -125,7 +125,7 @@ export default class StarterCodeTester extends BaseTester {
     for (const diff of diffs) {
       if (diff.toString() === "") {
         Logger.logError("Expected uncommenting code to return a diff");
-        Logger.logError("Are you sure there's a contiguous block of comments after the 'Uncomment the' marker?");
+        Logger.logError("Are you sure there's a contiguous block of comments after the 'Uncomment this' marker?");
         return;
       }
 

--- a/lib/uncommenter.test.ts
+++ b/lib/uncommenter.test.ts
@@ -6,12 +6,12 @@ test("", () => {
 
 import Uncommenter from "./uncommenter";
 
-const UNCOMMENT_PATTERN = /Uncomment the/;
+const UNCOMMENT_PATTERN = /Uncomment this/;
 
 const SAMPLE_PY_COMMENTED = `
 abcd = true
 
-# Uncomment the code below to pass the first stage
+# Uncomment this to pass the first stage
 #
 # # This is an assignment
 # a = b
@@ -40,7 +40,7 @@ yay = true
 
 const SAMPLE_GO_COMMENTED = `
 func main() {
-  // Uncomment the code below to pass the first stage
+  // Uncomment this to pass the first stage
   //
   // // This is an assignment
   // a := 1
@@ -64,7 +64,7 @@ func main() {
 
 const SAMPLE_HASKELL_COMMENTD = `
 main = do
- -- Uncomment the code below to pass the first stage
+ -- Uncomment this to pass the first stage
  -- a <- readLine
  -- b <- readLine
  -- -- Nested Comment
@@ -81,7 +81,7 @@ main = do
 
 const SAMPLE_JAVA_COMMENTED = `
 public static void main(String[] args) {
-  // Uncomment the code below to pass the first stage
+  // Uncomment this to pass the first stage
   //
   // // This is an assignment
   // int a = 1;
@@ -105,7 +105,7 @@ public static void main(String[] args) {
 
 const SAMPLE_KOTLIN_COMMENTED = `
 fun main(args: Array<String>) {
-  // Uncomment the code below to pass the first stage
+  // Uncomment this to pass the first stage
   //
   // // This is an assignment
   // val a = 1;
@@ -129,7 +129,7 @@ fun main(args: Array<String>) {
 
 const SAMPLE_PHP_COMMENTED = `
 <?php
-// Uncomment the code below to pass the first stage.
+// Uncomment this to pass the first stage.
 // $a = 1;
 // $b = 1;
 
@@ -147,7 +147,7 @@ $b = 1;
 `;
 
 const SAMPLE_JAVASCRIPT_COMMENTED = `
-// Uncomment the code below to pass the first stage
+// Uncomment this to pass the first stage
 // var a = 1;
 // var b = 2;
 // console.log(a + b);
@@ -160,7 +160,7 @@ console.log(a + b);
 `;
 
 const SAMPLE_CSHARP_COMMENTED = `
-// Uncomment the code below to pass the first stage
+// Uncomment this to pass the first stage
 // var a = 1;
 // var b = 2;
 // Console.WriteLine(a + b);
@@ -175,12 +175,12 @@ Console.WriteLine(a + b);
 const SAMPLE_TWO_MARKERS_COMMENTED = `
 a = b
 
-# Uncomment the code below to pass the first stage
+# Uncomment this to pass the first stage
 #
 # # First uncommented block
 # b = c
 
-# Uncomment the code below to pass the first stage
+# Uncomment this to pass the first stage
 #
 # # Second uncommented block
 # c = d
@@ -198,7 +198,7 @@ c = d
 
 const SAMPLE_OCAML_COMMENTED = `
 let main () =
-  (* Uncomment the code below to pass the first stage *)
+  (* Uncomment this to pass the first stage *)
   (* let a = 1 in *)
   (* let b = 2 in *)
   (* Printf.printf "%d\\n" (a + b) *)
@@ -343,7 +343,7 @@ test("uncommentedBlocksWithMarker", () => {
     `
     a = b
 
-    # Uncomment the code below to pass the first stage
+    # Uncomment this to pass the first stage
     # a = b
 
     c = d
@@ -351,7 +351,7 @@ test("uncommentedBlocksWithMarker", () => {
     UNCOMMENT_PATTERN
   ).uncommentedBlocksWithMarker;
 
-  const expected = `    # Uncomment the code below to pass the first stage
+  const expected = `    # Uncomment this to pass the first stage
     a = b`;
 
   expect(actual[0]).toBe(expected);


### PR DESCRIPTION
Reverts codecrafters-io/course-sdk#62

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the uncomment marker and related messages to "Uncomment this" across implementation and tests.
> 
> - **Core logic**:
>   - Update `StarterCodeUncommenter.UNCOMMENT_MARKER_PATTERN` to `/Uncomment this/` in `lib/starter-code-uncommenter.ts`.
> - **Error/Log messages**:
>   - Change references to the marker in `ensureDiffsExist()` in `lib/compilers/first-stage-solutions-compiler.ts`.
>   - Update tester log messages in `lib/testers/starter-code-tester.ts`.
> - **Tests**:
>   - Change `UNCOMMENT_PATTERN` and all sample fixture strings to use "Uncomment this" in `lib/uncommenter.test.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40fd0adb38dbbedcedce39108621b64d9da0bd6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->