### PR TITLE
Update Makefile to clone core repository with depth 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,6 @@ install:
 	if [ ! -L /usr/local/bin/course-sdk ]; then sudo ln -sf $(shell pwd)/main.out /usr/local/bin/course-sdk; fi
 
 update_schemas:
-	gh repo clone codecrafters-io/core /tmp/codecrafters-core-tmp
+	gh repo clone codecrafters-io/core /tmp/codecrafters-core-tmp --depth 1
 	cp /tmp/codecrafters-core-tmp/data/course_definition_schema.json ./schemas/course-definition.json
 	rm -rf /tmp/codecrafters-core-tmp


### PR DESCRIPTION
<img width="1312" height="312" alt="image" src="https://github.com/user-attachments/assets/76078c99-187a-43a0-9568-6f00ce55b55b" />

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates `update_schemas` to clone `codecrafters-io/core` with `--depth 1`.
> 
> - **Makefile**:
>   - `update_schemas`: add `--depth 1` to `gh repo clone` for a shallow clone of `codecrafters-io/core`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d789cf0ad4d98bf7ade9770234d3f8fa7f12b1cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->