### PR TITLE
Add lint step to course-sdk to ensure config.yml is always valid

### DIFF
--- a/commands/lint.ts
+++ b/commands/lint.ts
@@ -32,6 +32,13 @@ export default class LintCommand extends BaseCommand {
     console.log("");
 
     console.log("");
+    console.log("Linting YAML files...");
+    console.log("");
+    await this.lintYamlFiles();
+    console.log("Linting of YAML files complete.");
+    console.log("");
+
+    console.log("");
     console.log("Linting Markdown files...");
     console.log("");
     await this.lintMarkdownFiles();
@@ -82,6 +89,13 @@ export default class LintCommand extends BaseCommand {
     const dockerShellCommandExecutor = await this.dockerShellCommandExecutor("js-tools");
     await dockerShellCommandExecutor.exec(
       `prettier --prose-wrap="always" --write --ignore-path ./.prettierignore --no-error-on-unmatched-pattern "./**/*.md"`
+    );
+  }
+
+  async lintYamlFiles() {
+    const dockerShellCommandExecutor = await this.dockerShellCommandExecutor("js-tools");
+    await dockerShellCommandExecutor.exec(
+      `prettier --write --ignore-path ./.prettierignore --no-error-on-unmatched-pattern "./**/config.yml"`
     );
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add YAML linting using Prettier for `config.yml` files in the lint workflow.
> 
> - **Lint Command (`commands/lint.ts`)**:
>   - **YAML linting**: Integrates a new YAML lint step in `doRun()` between JS and Markdown linting.
>     - Adds `lintYamlFiles()` using `prettier` via `js-tools` to format/check `./**/config.yml`.
>     - Includes corresponding console output messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70a8ca5c3a097ec2cfd91ce6e6aea1a097194431. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->