### PR TITLE
Tweak Rust linting by ignoring unused variables and dead code

### DIFF
--- a/commands/lint.ts
+++ b/commands/lint.ts
@@ -103,7 +103,7 @@ export default class LintCommand extends BaseCommand {
     const dockerShellCommandExecutor = await this.dockerShellCommandExecutor("rust-tools");
     await dockerShellCommandExecutor.exec(`find . -name '*.rs' -exec rustfmt --edition "2024" --check -- {} +`);
     await dockerShellCommandExecutor.exec(
-      "[ -d compiled_starters/rust ] || exit 0 && (cd compiled_starters/rust && cargo clippy -- -D warnings)"
+      "[ -d compiled_starters/rust ] || exit 0 && (cd compiled_starters/rust && cargo clippy -- -D warnings -A unused-variables -A dead-code)"
     );
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts Rust linting to pass clippy with `-A unused-variables` and `-A dead-code` while still denying other warnings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9737368fbf77bcd7b71f2e8f108086cf7fe80c88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->