### PR TITLE
Add openrouter variable to env

### DIFF
--- a/.github/workflows/test-course-definition.yml
+++ b/.github/workflows/test-course-definition.yml
@@ -106,6 +106,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    # Avoid leaking secrets to forked PRs
+    if: github.event.pull_request.head.repo.fork == false
+
     permissions:
       contents: read
 

--- a/.github/workflows/test-course-definition.yml
+++ b/.github/workflows/test-course-definition.yml
@@ -152,6 +152,7 @@ jobs:
         working-directory: courses/${{github.event.repository.name}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CODECRAFTERS_SECRET_OPENROUTER_API_KEY: ${{ secrets.CODECRAFTERS_SECRET_OPENROUTER_API_KEY }}
 
   validate-schemas:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-course-definition.yml
+++ b/.github/workflows/test-course-definition.yml
@@ -155,6 +155,7 @@ jobs:
         working-directory: courses/${{github.event.repository.name}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Figure out a way to allow course-specific environment variables
           CODECRAFTERS_SECRET_OPENROUTER_API_KEY: ${{ secrets.CODECRAFTERS_SECRET_OPENROUTER_API_KEY }}
 
   validate-schemas:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Strengthens CI security and enables OpenRouter-dependent tests.
> 
> - Adds job-level guard `if: github.event.pull_request.head.repo.fork == false` to `test` (and `test_stage_descriptions`) to avoid leaking secrets to forks
> - Passes `CODECRAFTERS_SECRET_OPENROUTER_API_KEY` from `secrets` into `course-sdk test` environment
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fbb230e60f6bac0f733725a4f2339613211ee8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->