### PR TITLE
LLM API key fork protection

### DIFF
--- a/.github/workflows/test-course-definition.yml
+++ b/.github/workflows/test-course-definition.yml
@@ -106,6 +106,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    # Avoid leaking secrets to forked PRs
+    if: github.event.pull_request.head.repo.fork == false
+
     permissions:
       contents: read
 


### PR DESCRIPTION
Add fork protection to the `test` job to prevent leaking the OpenRouter API key to forked PRs, consistent with existing security patterns.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds fork protection to the CI workflow.
> 
> - Updates `test` job in `.github/workflows/test-course-definition.yml` to run only when `github.event.pull_request.head.repo.fork == false`, preventing secrets (e.g., `CODECRAFTERS_SECRET_OPENROUTER_API_KEY`) from leaking on forked PRs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3795e21e50b49e1c6c12ebcb0a747ef670970b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->