### PR TITLE
Bump rust version in `rust-tools` to 1.92

### DIFF
--- a/lib/dockerfiles/rust-tools.Dockerfile
+++ b/lib/dockerfiles/rust-tools.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.91-trixie
+FROM rust:1.92-trixie
 
 WORKDIR /workdir
 


### PR DESCRIPTION
Reason:

- Language template uses newer rust version. Claude code test failed (https://github.com/codecrafters-io/build-your-own-claude-code/actions/runs/21428090443/job/61701218284)

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Rust toolchain upgrade**
> 
> - Updates `lib/dockerfiles/rust-tools.Dockerfile` base image from `rust:1.91-trixie` to `rust:1.92-trixie`, standardizing the dev/CI toolchain; `clippy` and `rustfmt` installs unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ba312853f5ecf1b4e0a068f777cbbae6531bb8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->