### PR TITLE
Download new tester version if available

### DIFF
--- a/lib/tester-downloader.test.ts
+++ b/lib/tester-downloader.test.ts
@@ -5,13 +5,16 @@ import fs from "fs";
 
 test("downloadIfNeeded", async () => {
   const course = new Course("redis", "dummy", "dummy", [], "dummy");
-  const testerDir = await new TesterDownloader(course).downloadIfNeeded();
-  
-  // TODO: I'll remove this comment after PR review
-  // The testerDir is dependent on the latest available tester version,
-  // Right now we're just testing against the result from the function itself
-  // We cannot hardcode testerDir as before, what would be a good way to test this? 
-  // Or should I leave this as it is?
+  const downloader = new TesterDownloader(course);
+
+  // Independently fetch the latest version to compute expected path
+  const latestVersion = await downloader.fetchLatestTesterVersion();
+  const expectedTesterDir = `/tmp/testers/${course.slug}-${latestVersion}`;
+
+  const testerDir = await downloader.downloadIfNeeded();
+
+  // Verify the returned path matches the independently computed expected path
+  expect(testerDir).toBe(expectedTesterDir);
   expect(fs.existsSync(testerDir)).toBe(true);
   expect(fs.existsSync(`${testerDir}/test.sh`)).toBe(true);
 });

--- a/lib/tester-downloader.test.ts
+++ b/lib/tester-downloader.test.ts
@@ -5,12 +5,13 @@ import fs from "fs";
 
 test("downloadIfNeeded", async () => {
   const course = new Course("redis", "dummy", "dummy", [], "dummy");
-  await new TesterDownloader(course).downloadIfNeeded();
+  const testerDir = await new TesterDownloader(course).downloadIfNeeded();
   
-  const testersRoot = "/tmp/testers";
-  const entries = fs.readdirSync(testersRoot);
-  const redisDir = entries.find(entry => entry.startsWith("redis-"));
-  
-  expect(redisDir).toBeDefined();
-  expect(fs.existsSync(`${testersRoot}/${redisDir}/test.sh`)).toBe(true);
+  // TODO: I'll remove this comment after PR review
+  // The testerDir is dependent on the latest available tester version,
+  // Right now we're just testing against the result from the function itself
+  // We cannot hardcode testerDir as before, what would be a good way to test this? 
+  // Or should I leave this as it is?
+  expect(fs.existsSync(testerDir)).toBe(true);
+  expect(fs.existsSync(`${testerDir}/test.sh`)).toBe(true);
 });

--- a/lib/tester-downloader.test.ts
+++ b/lib/tester-downloader.test.ts
@@ -6,7 +6,11 @@ import fs from "fs";
 test("downloadIfNeeded", async () => {
   const course = new Course("redis", "dummy", "dummy", [], "dummy");
   await new TesterDownloader(course).downloadIfNeeded();
-
-  expect(fs.existsSync("/tmp/testers/redis")).toBe(true);
-  expect(fs.existsSync("/tmp/testers/redis/test.sh")).toBe(true);
+  
+  const testersRoot = "/tmp/testers";
+  const entries = fs.readdirSync(testersRoot);
+  const redisDir = entries.find(entry => entry.startsWith("redis-"));
+  
+  expect(redisDir).toBeDefined();
+  expect(fs.existsSync(`${testersRoot}/${redisDir}/test.sh`)).toBe(true);
 });

--- a/lib/tester-downloader.ts
+++ b/lib/tester-downloader.ts
@@ -11,7 +11,7 @@ export default class TesterDownloader {
   course: Course;
   testersRootDir: string;
   // Cache latest tester version
-  private latestTesterVersion?: string;
+  private latestVersion?: string;
 
   constructor(course: Course, testersRootDir?: string) {
     this.course = course;
@@ -23,15 +23,15 @@ export default class TesterDownloader {
   }
 
   async downloadIfNeeded(): Promise<string> {
-    this.latestTesterVersion = await this.fetchLatestTesterVersion();
+    this.latestVersion = await this.fetchLatestTesterVersion();
 
     if (await fs.promises.exists(this.testerDir)) {
       return this.testerDir;
     }
 
-    const compressedFilePath = path.join(this.testersRootDir, `${this.course.slug}-${this.latestTesterVersion}.tar.gz`);
+    const compressedFilePath = path.join(this.testersRootDir, `${this.course.slug}-${this.latestVersion}.tar.gz`);
     fs.mkdirSync(this.testersRootDir, { recursive: true });
-    const artifactUrl = `https://github.com/${this.testerRepositoryName}/releases/download/${this.latestTesterVersion}/${this.latestTesterVersion}_linux_amd64.tar.gz`;
+    const artifactUrl = `https://github.com/${this.testerRepositoryName}/releases/download/${this.latestVersion}/${this.latestVersion}_linux_amd64.tar.gz`;
     console.log(`Downloading ${artifactUrl}`);
 
     const response = await fetch(artifactUrl);
@@ -74,10 +74,10 @@ export default class TesterDownloader {
   }
 
   get testerDir() {
-    if (!this.latestTesterVersion) {
+    if (!this.latestVersion) {
       throw new Error("Must call downloadIfNeeded() before accessing testerDir");
     }
-    return this.getTesterDirFromVersion(this.latestTesterVersion)
+    return this.getTesterDirFromVersion(this.latestVersion)
   }
 
   private getTesterDirFromVersion(version: string) {

--- a/lib/tester-downloader.ts
+++ b/lib/tester-downloader.ts
@@ -7,9 +7,11 @@ import { promisify } from "node:util";
 
 export default class TesterDownloader {
   static DEFAULT_TESTERS_ROOT_DIR = "/tmp/testers";
-
+  
   course: Course;
   testersRootDir: string;
+  // Cache latest tester version
+  private latestTesterVersion?: string;
 
   constructor(course: Course, testersRootDir?: string) {
     this.course = course;
@@ -21,21 +23,18 @@ export default class TesterDownloader {
   }
 
   async downloadIfNeeded(): Promise<string> {
+    this.latestTesterVersion = await this.fetchLatestTesterVersion();
+
     if (await fs.promises.exists(this.testerDir)) {
       return this.testerDir;
     }
 
-    const compressedFilePath = path.join(this.testersRootDir, `${this.course.slug}.tar.gz`);
-
+    const compressedFilePath = path.join(this.testersRootDir, `${this.course.slug}-${this.latestTesterVersion}.tar.gz`);
     fs.mkdirSync(this.testersRootDir, { recursive: true });
-
-    const latestVersion = await this.latestTesterVersion();
     const artifactUrl = `https://github.com/${this.testerRepositoryName}/releases/download/${latestVersion}/${latestVersion}_linux_amd64.tar.gz`;
-
     console.log(`Downloading ${artifactUrl}`);
 
     const response = await fetch(artifactUrl);
-
     if (!response.ok) {
       throw new Error(`Failed to download tester. Status: ${response.status}. Response: ${await response.text()}`);
     }
@@ -56,7 +55,7 @@ export default class TesterDownloader {
     return this.testerDir;
   }
 
-  async latestTesterVersion() {
+  async fetchLatestTesterVersion() {
     const response = await fetch(`https://api.github.com/repos/${this.testerRepositoryName}/releases/latest`, {
       headers: process.env.GITHUB_TOKEN ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` } : {},
     });
@@ -75,7 +74,14 @@ export default class TesterDownloader {
   }
 
   get testerDir() {
-    return path.join(this.testersRootDir, this.course.slug);
+    if (!this.latestTesterVersion) {
+      throw new Error("Must call downloadIfNeeded() before accessing testerDir");
+    }
+    return this.getTesterDirFromVersion(this.latestTesterVersion)
+  }
+
+  getTesterDirFromVersion(version: string) {
+    return path.join(this.testersRootDir, `${this.course.slug}-${version}`);
   }
 
   get testerRepositoryName() {

--- a/lib/tester-downloader.ts
+++ b/lib/tester-downloader.ts
@@ -31,7 +31,7 @@ export default class TesterDownloader {
 
     const compressedFilePath = path.join(this.testersRootDir, `${this.course.slug}-${this.latestTesterVersion}.tar.gz`);
     fs.mkdirSync(this.testersRootDir, { recursive: true });
-    const artifactUrl = `https://github.com/${this.testerRepositoryName}/releases/download/${latestVersion}/${latestVersion}_linux_amd64.tar.gz`;
+    const artifactUrl = `https://github.com/${this.testerRepositoryName}/releases/download/${this.latestTesterVersion}/${this.latestTesterVersion}_linux_amd64.tar.gz`;
     console.log(`Downloading ${artifactUrl}`);
 
     const response = await fetch(artifactUrl);

--- a/lib/tester-downloader.ts
+++ b/lib/tester-downloader.ts
@@ -80,7 +80,7 @@ export default class TesterDownloader {
     return this.getTesterDirFromVersion(this.latestTesterVersion)
   }
 
-  getTesterDirFromVersion(version: string) {
+  private getTesterDirFromVersion(version: string) {
     return path.join(this.testersRootDir, `${this.course.slug}-${version}`);
   }
 

--- a/lib/tester-downloader.ts
+++ b/lib/tester-downloader.ts
@@ -7,7 +7,7 @@ import { promisify } from "node:util";
 
 export default class TesterDownloader {
   static DEFAULT_TESTERS_ROOT_DIR = "/tmp/testers";
-  
+
   course: Course;
   testersRootDir: string;
   // Cache latest tester version

--- a/lib/tester-downloader.ts
+++ b/lib/tester-downloader.ts
@@ -77,11 +77,7 @@ export default class TesterDownloader {
     if (!this.latestVersion) {
       throw new Error("Must call downloadIfNeeded() before accessing testerDir");
     }
-    return this.getTesterDirFromVersion(this.latestVersion)
-  }
-
-  private getTesterDirFromVersion(version: string) {
-    return path.join(this.testersRootDir, `${this.course.slug}-${version}`);
+    return path.join(this.testersRootDir, `${this.course.slug}-${this.latestVersion}`);
   }
 
   get testerRepositoryName() {


### PR DESCRIPTION
- Encountered this bug while testing claude code starter templates, when there was a newer version of the tester available but since an older tester version was present in the system, `downloadIfNeeded()` did not download the newer version at all.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the on-disk cache keying and makes `testerDir` dependent on call order, which may break any callers accessing `testerDir` before invoking `downloadIfNeeded()`.
> 
> **Overview**
> `TesterDownloader` now resolves the latest GitHub release tag up front, caches it, and uses it to version the local tester directory and tarball path (e.g. `slug-<version>`), preventing stale cached testers from blocking updates.
> 
> The version lookup method is renamed to `fetchLatestTesterVersion()`, and `testerDir` now requires `downloadIfNeeded()` to have run (throws otherwise). Tests are updated to assert the returned directory includes the latest version and that expected files exist at that path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 584f43f33dd0bc70b406436587231b6754b03f80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->