### PR TITLE
Fix: rust-tools version for Claude Code challenge

### DIFF
--- a/lib/dockerfiles/rust-tools.Dockerfile
+++ b/lib/dockerfiles/rust-tools.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.92-trixie
+FROM rust:1.93-trixie
 
 WORKDIR /workdir
 


### PR DESCRIPTION
Errors:

https://github.com/codecrafters-io/build-your-own-claude-code/actions/runs/22124308987/job/63950958649

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple Docker base image version bump; main risk is minor toolchain/compatibility differences with Rust 1.93.
> 
> **Overview**
> Updates the `lib/dockerfiles/rust-tools.Dockerfile` base image from `rust:1.92-trixie` to `rust:1.93-trixie` to align the Rust toolchain used in CI/build environments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43e6da541b971de928353986ee5c7be3787854d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->