### PR TITLE
Add preliminary support for Ada language

### DIFF
--- a/lib/models/language.ts
+++ b/lib/models/language.ts
@@ -58,6 +58,7 @@ export default class Language {
 
   get codeFileExtension(): string {
     const extensions: { [key: string]: string } = {
+      ada: "adb",
       c: "c",
       clojure: "clj",
       cpp: "cpp",

--- a/lib/models/language.ts
+++ b/lib/models/language.ts
@@ -9,6 +9,7 @@ export default class Language {
 
   static all() {
     return [
+      new Language("ada", "Ada"),
       new Language("c", "C"),
       new Language("cpp", "C++"),
       new Language("clojure", "Clojure"),

--- a/lib/uncommenter.ts
+++ b/lib/uncommenter.ts
@@ -4,6 +4,7 @@ export default class Uncommenter {
   private static DOUBLE_HYPHENS = /(^\s*)--\s{0,1}(.*)$/;
 
   private static REGEX_PATTERNS: { [key: string]: RegExp } = {
+    ada: Uncommenter.DOUBLE_HYPHENS,
     c: Uncommenter.DOUBLE_SLASHES,
     clojure: /(^\s*);;\s{0,1}(.*)$/,
     cpp: Uncommenter.DOUBLE_SLASHES,


### PR DESCRIPTION
Hi.
I'm not a TypeScript programmer, so I only added the code related to the Ada language myself. However, we couldn't build a program using only .adb (body) files without any corresponding .ads (spec) files. To support this, I used ChatGPT to write some additional code that extends the course-sdk to handle multiple file extensions.